### PR TITLE
Refactor/general

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,14 @@ function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
 }
 
+function show(el) {
+  el.classList.remove('hidden');
+}
+
+function hide(el) {
+  el.classList.add('hidden');
+}
+
 function createHexCode() {
   var hexChars = [];
   for (var i = 0; i < 6; i++) {
@@ -65,12 +73,6 @@ function changeColorBoxes() {
   });
 }
 
-function show(el) {
-  el.classList.remove('hidden');
-}
-function hide(el) {
-  el.classList.add('hidden');
-}
 
 function changeLocks() {
   currentColorPalette.forEach((color, i) => {

--- a/main.js
+++ b/main.js
@@ -66,13 +66,13 @@ function changeColorBoxes() {
 }
 
 function toggleLock(e) {
-  for (var i = 0; i < currentColorPalette.length; i++) {
+  currentColorPalette.forEach((color, i) => {
     if (e.target.parentNode.id === `box${i}`) {
-      currentColorPalette[i].locked = !currentColorPalette[i].locked;
-      document.getElementById(`lock${i}`).classList.toggle('hidden');
-      document.getElementById(`unlock${i}`).classList.toggle('hidden');
-    }
-  }
+        color.locked = !color.locked;
+        document.getElementById(`lock${i}`).classList.toggle('hidden');
+        document.getElementById(`unlock${i}`).classList.toggle('hidden');
+      }
+  })
 }
 
 function displayPalette() {
@@ -88,11 +88,7 @@ function loadPage() {
 }
 
 function savePalettes() {
-  var newPalette = [];
-  for (var i = 0; i < currentColorPalette.length; i++) {
-    newPalette.push(currentColorPalette[i]);
-  }
-  savedPalettes.push(newPalette);
+  savedPalettes.push([...currentColorPalette]);
   displaySavedPalettes();
   displayPalette();
 }

--- a/main.js
+++ b/main.js
@@ -33,8 +33,7 @@ function createHexCode() {
   var hexCode = hexChars.join('');
   return {
     locked: false,
-    code: `#${hexCode}`,
-    id: Date.now()
+    code: `#${hexCode}`
   };
 }
 
@@ -66,6 +65,24 @@ function changeColorBoxes() {
   });
 }
 
+function show(el) {
+  el.classList.remove('hidden');
+}
+function hide(el) {
+  el.classList.add('hidden');
+}
+
+function changeLocks() {
+  currentColorPalette.forEach((color, i) => {
+    if (color.locked) {
+      show(document.getElementById(`lock${i}`));
+      hide(document.getElementById(`unlock${i}`));
+    } else {
+      hide(document.getElementById(`lock${i}`));
+      show(document.getElementById(`unlock${i}`));
+    }});
+}
+
 function toggleLock(e) {
   currentColorPalette.forEach((color, i) => {
     if (e.target.parentNode.id === `box${i}`) {
@@ -89,7 +106,8 @@ function loadPage() {
 }
 
 function savePalettes() {
-  savedPalettes.push([...currentColorPalette]);
+  let currentCopy = currentColorPalette.map((color) => ({...color}));
+  savedPalettes.push(currentCopy);
   displaySavedPalettes();
   displayPalette();
 }
@@ -132,17 +150,17 @@ function changeSavedDisplay(e) {
 function editPalette(e) {
   savedPalettes.forEach((palette, i) => {
     if (e.target.parentNode.id === `${i}` && e.target.className !== 'delete') {
-        displayEditPalette(palette)
+        updateCurrentPalette(palette);
         changeHexCodes();
         changeColorBoxes();
+        changeLocks();
       }
   })
 }
 
-function displayEditPalette(palette) {
-    currentColorPalette.forEach((color, i) => {
-        color.code = palette[i].code;
-    })
+function updateCurrentPalette(palette) {
+    let paletteCopy = palette.map((color) => ({...color}))
+    currentColorPalette = paletteCopy;
 }
 
 function changeTitleColor(e) {

--- a/main.js
+++ b/main.js
@@ -1,6 +1,4 @@
 // Global Variables
-var hexCodes = document.querySelectorAll('h2');
-var colorBoxes = document.querySelectorAll('.color-box');
 var paletteBtn = document.querySelector('#newPaletteBtn');
 var boxContainer = document.querySelector('.box-container');
 var savePaletteBtn = document.querySelector('#savePaletteBtn');
@@ -24,84 +22,86 @@ main.addEventListener('mouseover', changeTitleColor);
 
 // Event Handlers
 function getRandomIndex(array) {
-    return Math.floor(Math.random() * array.length);
+  return Math.floor(Math.random() * array.length);
 }
 
 function createHexCode() {
-    var hexChars = [];
-    for (var i = 0; i < 6; i++) {
-        hexChars.push(hexOptions[getRandomIndex(hexOptions)]);
-    }
-    var hexCode = hexChars.join('');
-    return {
-        locked: false,
-        code: `#${hexCode}`
-    }
+  var hexChars = [];
+  for (var i = 0; i < 6; i++) {
+    hexChars.push(hexOptions[getRandomIndex(hexOptions)]);
+  }
+  var hexCode = hexChars.join('');
+  return {
+    locked: false,
+    code: `#${hexCode}`,
+  };
 }
 
 function loadPalette() {
-    var newPalette = [];
-    for (var i = 0; i < 5; i++) {
-        newPalette.push(createHexCode());
-    }
-    currentColorPalette = newPalette;
+  var newPalette = [];
+  for (var i = 0; i < 5; i++) {
+    newPalette.push(createHexCode());
+  }
+  currentColorPalette = newPalette;
 }
 
 function getNewPalette() {
   currentColorPalette.forEach((color, i) => {
-    if(!color.locked) currentColorPalette.splice(i, 1, createHexCode())
-  })
+    if (!color.locked) currentColorPalette.splice(i, 1, createHexCode());
+  });
 }
 
 function changeHexCodes() {
-    for (var i = 0; i < hexCodes.length; i++) {
-        hexCodes[i].innerText = currentColorPalette[i].code;
-    }
+  var hexCodes = document.querySelectorAll('h2');
+  hexCodes.forEach((code, i) => {
+    code.innerText = currentColorPalette[i].code;
+  });
 }
 
 function changeColorBoxes() {
-    for (var i = 0; i < colorBoxes.length; i++) {
-        colorBoxes[i].style.background = currentColorPalette[i].code;
-    }
+  var colorBoxes = document.querySelectorAll('.color-box');
+  colorBoxes.forEach((box, i) => {
+    box.style.background = currentColorPalette[i].code;
+  });
 }
 
 function toggleLock(e) {
-    for (var i = 0; i < currentColorPalette.length; i++) {
-        if (e.target.parentNode.id === `box${i}`) {
-            currentColorPalette[i].locked = !currentColorPalette[i].locked;
-            document.getElementById(`lock${i}`).classList.toggle('hidden');
-            document.getElementById(`unlock${i}`).classList.toggle('hidden');
-        }
+  for (var i = 0; i < currentColorPalette.length; i++) {
+    if (e.target.parentNode.id === `box${i}`) {
+      currentColorPalette[i].locked = !currentColorPalette[i].locked;
+      document.getElementById(`lock${i}`).classList.toggle('hidden');
+      document.getElementById(`unlock${i}`).classList.toggle('hidden');
     }
+  }
 }
 
 function displayPalette() {
-    getNewPalette();
-    changeHexCodes();
-    changeColorBoxes();
+  getNewPalette();
+  changeHexCodes();
+  changeColorBoxes();
 }
 
 function loadPage() {
-    loadPalette();
-    changeHexCodes();
-    changeColorBoxes();
+  loadPalette();
+  changeHexCodes();
+  changeColorBoxes();
 }
 
 function savePalettes() {
-    var newPalette = [];
-    for (var i = 0; i < currentColorPalette.length; i++) {
-        newPalette.push(currentColorPalette[i]);
-    }
-    savedPalettes.push(newPalette);
-    displaySavedPalettes();
-    displayPalette();
+  var newPalette = [];
+  for (var i = 0; i < currentColorPalette.length; i++) {
+    newPalette.push(currentColorPalette[i]);
+  }
+  savedPalettes.push(newPalette);
+  displaySavedPalettes();
+  displayPalette();
 }
 
 function displaySavedPalettes() {
-    savedSectionMsg.classList.add('hidden');
-    savedPalettesContainer.innerHTML = '';
-    for (var i = 0; i < savedPalettes.length; i++) {
-        savedPalettesContainer.innerHTML += `
+  savedSectionMsg.classList.add('hidden');
+  savedPalettesContainer.innerHTML = '';
+  for (var i = 0; i < savedPalettes.length; i++) {
+    savedPalettesContainer.innerHTML += `
         <section class="mini-container" id="${i}">
             <section class="mini-palette" style="background-color: ${savedPalettes[i][0].code}"></section>
             <section class="mini-palette" style="background-color: ${savedPalettes[i][1].code}"></section>
@@ -111,47 +111,48 @@ function displaySavedPalettes() {
             <img class="delete" data-index-number="${i}" src="./icons/delete.png">
         </section>
         `;
-    }
+  }
 }
 
 function deletePalette(e) {
-    if (e.target.className === 'delete') {
-        savedPalettes.splice(e.target.dataset.indexNumber, 1);
-    }
+  if (e.target.className === 'delete') {
+    savedPalettes.splice(e.target.dataset.indexNumber, 1);
+  }
 }
 
 function showMessage() {
-    if (savedPalettesContainer.innerHTML === '') {
-        savedPalettesContainer.innerHTML = `<h4>No saved palettes yet!</h4>`;
-    }
+  if (savedPalettesContainer.innerHTML === '') {
+    savedPalettesContainer.innerHTML = `<h4>No saved palettes yet!</h4>`;
+  }
 }
 
 function changeSavedDisplay(e) {
-    deletePalette(e);
-    displaySavedPalettes();
-    showMessage();
+  deletePalette(e);
+  displaySavedPalettes();
+  showMessage();
 }
 
 function editPalette(e) {
-    for (var i = 0; i < savedPalettes.length; i++) {
-        if (e.target.parentNode.id === `${i}` && e.target.className !== 'delete') {
-            displayEditPalette(i);
-            changeHexCodes();
-            changeColorBoxes();
-        }
-     }
+  for (var i = 0; i < savedPalettes.length; i++) {
+    if (e.target.parentNode.id === `${i}` && e.target.className !== 'delete') {
+      displayEditPalette(i);
+      changeHexCodes();
+      changeColorBoxes();
+    }
+  }
 }
 
 function displayEditPalette(i) {
-    for (var j = 0; j < currentColorPalette.length; j++) {
-        currentColorPalette[j].code = savedPalettes[i][j].code;
-    }
+  for (var j = 0; j < currentColorPalette.length; j++) {
+    currentColorPalette[j].code = savedPalettes[i][j].code;
+  }
 }
 
 function changeTitleColor(e) {
-    if (e.target.className === "title") {
-        title.style.color = currentColorPalette[getRandomIndex(currentColorPalette)].code;
-    } else {
-        title.style.color = `#000000`;
-    }
+  if (e.target.className === 'title') {
+    title.style.color =
+      currentColorPalette[getRandomIndex(currentColorPalette)].code;
+  } else {
+    title.style.color = `#000000`;
+  }
 }

--- a/main.js
+++ b/main.js
@@ -34,6 +34,7 @@ function createHexCode() {
   return {
     locked: false,
     code: `#${hexCode}`,
+    id: Date.now()
   };
 }
 
@@ -129,19 +130,19 @@ function changeSavedDisplay(e) {
 }
 
 function editPalette(e) {
-  for (var i = 0; i < savedPalettes.length; i++) {
+  savedPalettes.forEach((palette, i) => {
     if (e.target.parentNode.id === `${i}` && e.target.className !== 'delete') {
-      displayEditPalette(i);
-      changeHexCodes();
-      changeColorBoxes();
-    }
-  }
+        displayEditPalette(palette)
+        changeHexCodes();
+        changeColorBoxes();
+      }
+  })
 }
 
-function displayEditPalette(i) {
-  for (var j = 0; j < currentColorPalette.length; j++) {
-    currentColorPalette[j].code = savedPalettes[i][j].code;
-  }
+function displayEditPalette(palette) {
+    currentColorPalette.forEach((color, i) => {
+        color.code = palette[i].code;
+    })
 }
 
 function changeTitleColor(e) {

--- a/main.js
+++ b/main.js
@@ -93,21 +93,21 @@ function savePalettes() {
   displayPalette();
 }
 
+
 function displaySavedPalettes() {
   savedSectionMsg.classList.add('hidden');
   savedPalettesContainer.innerHTML = '';
-  for (var i = 0; i < savedPalettes.length; i++) {
+  savedPalettes.forEach((palette, i) => {
     savedPalettesContainer.innerHTML += `
-        <section class="mini-container" id="${i}">
-            <section class="mini-palette" style="background-color: ${savedPalettes[i][0].code}"></section>
-            <section class="mini-palette" style="background-color: ${savedPalettes[i][1].code}"></section>
-            <section class="mini-palette" style="background-color: ${savedPalettes[i][2].code}"></section>
-            <section class="mini-palette" style="background-color: ${savedPalettes[i][3].code}"></section>
-            <section class="mini-palette" style="background-color: ${savedPalettes[i][4].code}"></section>
-            <img class="delete" data-index-number="${i}" src="./icons/delete.png">
-        </section>
-        `;
-  }
+      <section class="mini-container" id="${i}">
+        <img class="delete" data-index-number="${i}" src="./icons/delete.png">
+      </section>`;
+    addMiniPalettes(palette, i);
+  });
+}
+  
+function addMiniPalettes(palette, index) {
+  palette.forEach(color => savedPalettesContainer.children[index].innerHTML += `<section class="mini-palette" style="background:${color.code}"></section>`);
 }
 
 function deletePalette(e) {

--- a/main.js
+++ b/main.js
@@ -48,11 +48,9 @@ function loadPalette() {
 }
 
 function getNewPalette() {
-  for (var i = 0; i < currentColorPalette.length; i++) {
-    if (!currentColorPalette[i].locked) {
-        currentColorPalette.splice(i, 1, createHexCode());
-    }
-  }
+  currentColorPalette.forEach((color, i) => {
+    if(!color.locked) currentColorPalette.splice(i, 1, createHexCode())
+  })
 }
 
 function changeHexCodes() {


### PR DESCRIPTION
- Use forEach in getNewPalette
- Fix indentation, remove unnecessary global variables
- Use the spread operator instead of for loop to make a deep copy of the current palette
- Dynamically add mini palettes to the saved cover section
- Use forEach in editPalette and displayEditPalette
- Make deep copies of palettes to keep locked information for saved palettes
- Move helper functions to the top of event handlers